### PR TITLE
Bugfix: for parameters that have multiple values, sort the values for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ AFNetworking, for example—with almost no changes to your code.
 * Works on macOS, iOS, and tvOS
 
 
-## What’s New in URLMock 1.3.4
+## What’s New in URLMock 1.3.5
 
-URLMock 1.3.4 adds support for parsing query strings that have multiple values for the same
-parameter name. These values are parsed into sets.
+URLMock 1.3.5 bugfix: when having a URL with multiple values for the same parameter name
+could fail to match it against the same URL if parameters were specified in different order
 
 
 ## Installation

--- a/Tests/Supporting Files/URLMockTests-Info.plist
+++ b/Tests/Supporting Files/URLMockTests-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
+++ b/Tests/Unit Tests/Mock URL Protocol/UMKMockURLProtocolTests.m
@@ -113,6 +113,12 @@
     NSURL *testURL4 = [NSURL URLWithString:@"http://domain?b=bar&c=baz&a=foo"];
     NSURL *canonicalURL4 = [UMKMockURLProtocol canonicalURLForURL:testURL4];
     XCTAssertEqualObjects(canonicalURL3, canonicalURL4, @"canonical URLs should be equal regardless of parameter order");
+
+    NSURL *testURL5 = [NSURL URLWithString:@"http://domain?arg=foo&arg=bar&arg=baz&arg=qux&arg=quux&arg=quuz"];
+    NSURL *canonicalURL5 = [UMKMockURLProtocol canonicalURLForURL:testURL5];
+    XCTAssertEqualObjects(canonicalURL5.absoluteString,
+                          @"http://domain?arg=bar&arg=baz&arg=foo&arg=quux&arg=quuz&arg=qux",
+                          @"canonical URL should have consistent order of set parameters");
 }
 
 @end

--- a/URLMock.podspec
+++ b/URLMock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "URLMock"
-  s.version      = "1.3.4"
+  s.version      = "1.3.5"
 
   s.summary      = "A Cocoa framework for mocking and stubbing URL requests and responses."
   s.description  = <<-DESC

--- a/URLMock/Categories/NSDictionary+UMKURLEncoding.m
+++ b/URLMock/Categories/NSDictionary+UMKURLEncoding.m
@@ -183,7 +183,7 @@
 - (NSArray<UMKParameterPair *> *)umk_parameterPairsWithKey:(NSString *)key
 {
     NSMutableArray<UMKParameterPair *> *pairs = [[NSMutableArray alloc] initWithCapacity:self.count];
-    for (id element in self) {
+    for (id element in [self.allObjects sortedArrayUsingSelector:@selector(compare:)]) {
         [pairs addObjectsFromArray:[element umk_parameterPairsWithKey:key]];
     }
     

--- a/URLMock/Supporting Files/URLMock-Info.plist
+++ b/URLMock/Supporting Files/URLMock-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- bugfix: when having a URL with multiple values for the same parameter name, it could fail to match it against the same URL if parameters were specified in different order

Sort the values coming out of a set, before producing parameter pairs. This adds consistency producing canonical URLs